### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/bitloops/ddd-hexagonal-cqrs-es-eda/security/code-scanning/2](https://github.com/bitloops/ddd-hexagonal-cqrs-es-eda/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided steps, the workflow primarily involves reading repository contents and running tests, so the minimal permissions required are `contents: read`. If additional permissions are needed (e.g., for pull requests), they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
